### PR TITLE
Hide navigation block on overview page when hide sidebar field is checked

### DIFF
--- a/src/Plugin/Block/CampaignsAbstractBlockBase.php
+++ b/src/Plugin/Block/CampaignsAbstractBlockBase.php
@@ -76,10 +76,13 @@ abstract class CampaignsAbstractBlockBase extends BlockBase implements Container
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
   protected function getCampaign() {
-    if ($this->node->bundle() == 'localgov_campaigns_page' and $this->node->field_campaign->entity) {
-      return $this->node->field_campaign->entity;
+    if ($this->node instanceof NodeInterface) {
+      if ($this->node->bundle() == 'localgov_campaigns_page' and $this->node->field_campaign->entity) {
+        return $this->node->field_campaign->entity;
+      }
+      return $this->node->bundle() == 'localgov_campaigns_overview' ? $this->node : NULL;
     }
-    return $this->node->bundle() == 'localgov_campaigns_overview' ? $this->node : NULL;
+    return NULL;
   }
 
   /**

--- a/src/Plugin/Block/CampaignsNavigationBlock.php
+++ b/src/Plugin/Block/CampaignsNavigationBlock.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\localgov_campaigns\Plugin\Block;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;
 
@@ -103,6 +105,20 @@ class CampaignsNavigationBlock extends CampaignsAbstractBlockBase {
     }
 
     return $links;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    if (!is_null($this->node) &&
+     $this->node->hasField('field_hide_sidebar') &&
+     $this->node->field_hide_sidebar->value == 1
+    ) {
+      return AccessResult::neutral();
+    }
+
+    return parent::blockAccess($account);
   }
 
   /**

--- a/tests/src/Functional/CampaignBlocksTest.php
+++ b/tests/src/Functional/CampaignBlocksTest.php
@@ -172,6 +172,14 @@ class CampaignBlocksTest extends BrowserTestBase {
     $this->assertSession()->pageTextNotContains($overview_title);
     $this->assertSession()->pageTextNotContains($page1_title);
     $this->assertSession()->pageTextNotContains($page2_title);
+
+    // Test hide sidebar field.
+    $overview->set('field_hide_sidebar', ['value' => 1]);
+    $overview->save();
+    $this->drupalGet($overview->toUrl()->toString());
+    $this->assertSession()->responseNotContains('block-localgov-campaign-navigation');
+    $this->drupalGet($page1->toUrl()->toString());
+    $this->assertSession()->responseContains('block-localgov-campaign-navigation');
   }
 
 }


### PR DESCRIPTION
Also fixes an issue when `$this->node` is not set.

Closes #13 