### PR TITLE
Hide page header block for campaign content types

### DIFF
--- a/localgov_campaigns.services.yml
+++ b/localgov_campaigns.services.yml
@@ -1,0 +1,6 @@
+services:
+  # Alter page header.
+  localgov_campaigns.page_header:
+    class: Drupal\localgov_campaigns\EventSubscriber\PageHeaderSubscriber
+    tags:
+      - { name: 'event_subscriber' }

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\localgov_campaigns\EventSubscriber;
+
+use Drupal\node\Entity\Node;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
+
+/**
+ * Class PageHeaderSubscriber.
+ *
+ * @package Drupal\localgov_campaigns\EventSubscriber
+ */
+class PageHeaderSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PageHeaderDisplayEvent::EVENT_NAME => ['setPageHeader', 0],
+    ];
+  }
+
+  /**
+   * Hide page header block.
+   */
+  public function setPageHeader(PageHeaderDisplayEvent $event) {
+    if ($event->getEntity() instanceof Node &&
+      ($event->getEntity()->bundle() == 'localgov_campaigns_overview' ||
+      $event->getEntity()->bundle() == 'localgov_campaigns_page')
+    ) {
+      $event->setVisibility(FALSE);
+    }
+  }
+
+}


### PR DESCRIPTION
Subscribes to the PageHeaderDisplayEvent event provided in the feature/localgov-87-title-block branch in localgov_core to  hide the PageHeaderBlock block.

Related merge requests:

- Block and event logic: https://github.com/localgovdrupal/localgov_core/pull/25
- Change title and lede on guide pages: https://github.com/localgovdrupal/localgov_guides/pull/21

Discussion of why this block exists and does what is does is here: https://github.com/localgovdrupal/localgov/issues/87