### PR TITLE
Homepage support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "minimum-stability": "dev",
   "require": {
     "drupal/layout_paragraphs": "^1.0@beta",
-    "drupal/paragraphs": "^1.11"
+    "drupal/paragraphs": "^1.11",
+    "localgovdrupal/localgov_paragraphs": "dev-master"
   },
   "extra": {
     "enable-patching": true,

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,6 @@
   "minimum-stability": "dev",
   "require": {
     "drupal/layout_paragraphs": "dev-1.0.x",
-    "drupal/paragraphs": "^1.11",
-    "drupal/pathauto": "^1.8",
-    "drupal/token": "^1.7",
     "localgovdrupal/localgov_paragraphs": "dev-master"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -6,23 +6,18 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "drupal/layout_paragraphs": "^1.0@beta",
+    "drupal/layout_paragraphs": "dev-1.0.x",
     "drupal/paragraphs": "^1.11",
     "drupal/pathauto": "^1.8",
     "drupal/token": "^1.7",
     "localgovdrupal/localgov_paragraphs": "dev-master"
   },
   "extra": {
-    "enable-patching": true,
     "composer-exit-on-patch-failure": true,
     "patchLevel": {
       "drupal/core": "-p2"
     },
     "patches": {
-      "drupal/layout_paragraphs": {
-        "Fix to layout_paragraphs to support Claro, see: https://www.drupal.org/project/layout_paragraphs/issues/3158842": "https://www.drupal.org/files/issues/2020-07-13/support-layout-paragraphs-in-claro-3158842-2.patch",
-        "Schema fixes #3161030": "https://www.drupal.org/files/issues/2020-07-23/layout-paragraphs-schema-errors-3161030-3.patch"
-      }
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,8 @@
   "require": {
     "drupal/layout_paragraphs": "^1.0@beta",
     "drupal/paragraphs": "^1.11",
+    "drupal/pathauto": "^1.8",
+    "drupal/token": "^1.7",
     "localgovdrupal/localgov_paragraphs": "dev-master"
   },
   "extra": {

--- a/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
+++ b/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - paragraphs.paragraphs_type.localgov_box_link
     - paragraphs.paragraphs_type.localgov_call_out_box
     - paragraphs.paragraphs_type.localgov_fact_box
+    - paragraphs.paragraphs_type.localgov_featured_campaign
     - paragraphs.paragraphs_type.localgov_ia_block
     - paragraphs.paragraphs_type.localgov_image
     - paragraphs.paragraphs_type.localgov_labelled_icon
@@ -44,6 +45,7 @@ settings:
       localgov_video: localgov_video
       localgov_ia_block: localgov_ia_block
       localgov_labelled_icon: localgov_labelled_icon
+      localgov_featured_campaign: localgov_featured_campaign
       localgov_newsroom_teaser: localgov_newsroom_teaser
       localgov_subscribe_panel: localgov_subscribe_panel
       page_section: page_section
@@ -57,6 +59,9 @@ settings:
       localgov_fact_box:
         enabled: true
         weight: 3
+      localgov_featured_campaign:
+        enabled: true
+        weight: 23
       localgov_ia_block:
         enabled: true
         weight: 21

--- a/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
+++ b/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
@@ -13,6 +13,7 @@ dependencies:
     - paragraphs.paragraphs_type.localgov_link_and_summary
     - paragraphs.paragraphs_type.localgov_newsroom_teaser
     - paragraphs.paragraphs_type.localgov_quote
+    - paragraphs.paragraphs_type.localgov_subscribe_panel
     - paragraphs.paragraphs_type.localgov_text
     - paragraphs.paragraphs_type.localgov_video
     - paragraphs.paragraphs_type.page_section
@@ -44,6 +45,7 @@ settings:
       localgov_ia_block: localgov_ia_block
       localgov_labelled_icon: localgov_labelled_icon
       localgov_newsroom_teaser: localgov_newsroom_teaser
+      localgov_subscribe_panel: localgov_subscribe_panel
       page_section: page_section
     target_bundles_drag_drop:
       localgov_box_link:
@@ -73,6 +75,9 @@ settings:
       localgov_quote:
         enabled: true
         weight: 6
+      localgov_subscribe_panel:
+        enabled: true
+        weight: 29
       localgov_text:
         enabled: true
         weight: 7

--- a/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
+++ b/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
@@ -7,12 +7,15 @@ dependencies:
     - paragraphs.paragraphs_type.localgov_box_link
     - paragraphs.paragraphs_type.localgov_call_out_box
     - paragraphs.paragraphs_type.localgov_fact_box
-    - paragraphs.paragraphs_type.localgov_link_and_summary
+    - paragraphs.paragraphs_type.localgov_ia_block
     - paragraphs.paragraphs_type.localgov_image
-    - paragraphs.paragraphs_type.localgov_text
-    - paragraphs.paragraphs_type.page_section
+    - paragraphs.paragraphs_type.localgov_labelled_icon
+    - paragraphs.paragraphs_type.localgov_link_and_summary
+    - paragraphs.paragraphs_type.localgov_newsroom_teaser
     - paragraphs.paragraphs_type.localgov_quote
+    - paragraphs.paragraphs_type.localgov_text
     - paragraphs.paragraphs_type.localgov_video
+    - paragraphs.paragraphs_type.page_section
   module:
     - entity_reference_revisions
 id: node.localgov_campaigns_overview.localgov_campaigns_content
@@ -33,12 +36,15 @@ settings:
       localgov_box_link: localgov_box_link
       localgov_call_out_box: localgov_call_out_box
       localgov_fact_box: localgov_fact_box
-      localgov_link_and_summary: localgov_link_and_summary
       localgov_image: localgov_image
-      localgov_text: localgov_text
+      localgov_link_and_summary: localgov_link_and_summary
       localgov_quote: localgov_quote
-      page_section: page_section
+      localgov_text: localgov_text
       localgov_video: localgov_video
+      localgov_ia_block: localgov_ia_block
+      localgov_labelled_icon: localgov_labelled_icon
+      localgov_newsroom_teaser: localgov_newsroom_teaser
+      page_section: page_section
     target_bundles_drag_drop:
       localgov_box_link:
         enabled: true
@@ -49,22 +55,31 @@ settings:
       localgov_fact_box:
         enabled: true
         weight: 3
-      localgov_link_and_summary:
+      localgov_ia_block:
         enabled: true
-        weight: 5
+        weight: 21
       localgov_image:
         enabled: true
         weight: 4
-      localgov_text:
+      localgov_labelled_icon:
         enabled: true
-        weight: 7
-      page_section:
+        weight: 23
+      localgov_link_and_summary:
         enabled: true
-        weight: 100
+        weight: 5
+      localgov_newsroom_teaser:
+        enabled: true
+        weight: 26
       localgov_quote:
         enabled: true
         weight: 6
+      localgov_text:
+        enabled: true
+        weight: 7
       localgov_video:
         enabled: true
         weight: 8
+      page_section:
+        enabled: true
+        weight: 100
 field_type: entity_reference_revisions

--- a/config/install/paragraphs.paragraphs_type.page_section.yml
+++ b/config/install/paragraphs.paragraphs_type.page_section.yml
@@ -14,6 +14,7 @@ behavior_plugins:
   layout_paragraphs:
     enabled: true
     available_layouts:
+      localgov_campaigns_one_column_flexible: Flexible
       layout_onecol: 'One column'
       layout_twocol: 'Two column'
       layout_threecol_33_34_33: 'Three column 33/34/33'

--- a/css/one-column-flexible.css
+++ b/css/one-column-flexible.css
@@ -1,0 +1,10 @@
+/**
+ * @file
+ * Style rules for the One column flexible layout.
+ */
+
+/* Mimic Bootstrap's .row */
+.row {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/localgov_campaigns.layouts.yml
+++ b/localgov_campaigns.layouts.yml
@@ -8,7 +8,7 @@ localgov_campaigns_one_column_flexible:
  label: Flexible
  category: 'Columns: 1'
  template: templates/layout--onecol--flexible
- library: layout_discovery/onecol
+ library: localgov_campaigns/one-column-flexible
  icon_map:
    - [content]
  regions:

--- a/localgov_campaigns.layouts.yml
+++ b/localgov_campaigns.layouts.yml
@@ -1,0 +1,16 @@
+# A custom one column layout.
+#
+# It fits side by side as many items as possible.
+#
+# @see https://www.drupal.org/docs/drupal-apis/layout-api/how-to-register-layouts
+#
+localgov_campaigns_one_column_flexible:
+ label: Flexible
+ category: 'Columns: 1'
+ template: templates/layout--onecol--flexible
+ library: layout_discovery/onecol
+ icon_map:
+   - [content]
+ regions:
+   content:
+    label: Content

--- a/localgov_campaigns.libraries.yml
+++ b/localgov_campaigns.libraries.yml
@@ -1,0 +1,6 @@
+one-column-flexible:
+  css:
+    layout:
+      css/one-column-flexible.css: {}
+  dependencies:
+    - layout_discovery/onecol

--- a/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.info.yml
+++ b/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - localgov_core:localgov_core
   - localgov_core:localgov_media
   - localgov_paragraphs:localgov_paragraphs
+  - localgov_paragraphs:localgov_homepage_paragraphs

--- a/templates/layout--onecol--flexible.html.twig
+++ b/templates/layout--onecol--flexible.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme template to display a one-column **flexible** layout.
+ *
+ * Available variables:
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--onecol',
+    'layout--onecol__flexible',
+  ]
+%}
+{% if content %}
+  <div{{ attributes.addClass(classes) }}>
+    <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content', 'row') }}>
+      {{ content.content }}
+    </div>
+  </div>
+{% endif %}

--- a/tests/src/Functional/CampaignBlocksTest.php
+++ b/tests/src/Functional/CampaignBlocksTest.php
@@ -159,24 +159,24 @@ class CampaignBlocksTest extends BrowserTestBase {
     $this->assertSession()->responseContains('block-localgov-campaign-navigation');
     $results = $this->xpath($xpath);
     $this->assertEquals(3, count($results));
-    $this->assertContains($overview_title, $results[0]->getText());
-    $this->assertNotContains($overview->toUrl()->toString(), $results[0]->getHtml());
-    $this->assertContains($page1_title, $results[1]->getText());
-    $this->assertContains($page1->toUrl()->toString(), $results[1]->getHtml());
-    $this->assertContains($page2_title, $results[2]->getText());
-    $this->assertContains($page2->toUrl()->toString(), $results[2]->getHtml());
+    $this->assertStringContainsString($overview_title, $results[0]->getText());
+    $this->assertStringNotContainsString($overview->toUrl()->toString(), $results[0]->getHtml());
+    $this->assertStringContainsString($page1_title, $results[1]->getText());
+    $this->assertStringContainsString($page1->toUrl()->toString(), $results[1]->getHtml());
+    $this->assertStringContainsString($page2_title, $results[2]->getText());
+    $this->assertStringContainsString($page2->toUrl()->toString(), $results[2]->getHtml());
 
     // Test campaign page.
     $this->drupalGet($page1->toUrl()->toString());
     $this->assertSession()->responseContains('block-localgov-campaign-navigation');
     $results = $this->xpath($xpath);
     $this->assertEquals(3, count($results));
-    $this->assertContains($overview_title, $results[0]->getText());
-    $this->assertContains($overview->toUrl()->toString(), $results[0]->getHtml());
-    $this->assertContains($page1_title, $results[1]->getText());
-    $this->assertNotContains($page1->toUrl()->toString(), $results[1]->getHtml());
-    $this->assertContains($page2_title, $results[2]->getText());
-    $this->assertContains($page2->toUrl()->toString(), $results[2]->getHtml());
+    $this->assertStringContainsString($overview_title, $results[0]->getText());
+    $this->assertStringContainsString($overview->toUrl()->toString(), $results[0]->getHtml());
+    $this->assertStringContainsString($page1_title, $results[1]->getText());
+    $this->assertStringNotContainsString($page1->toUrl()->toString(), $results[1]->getHtml());
+    $this->assertStringContainsString($page2_title, $results[2]->getText());
+    $this->assertStringContainsString($page2->toUrl()->toString(), $results[2]->getHtml());
 
     // Test article.
     $this->drupalGet($article->toUrl()->toString());


### PR DESCRIPTION
Change summary:
- Adds three Homepage related Paragraphs (IA block, CTA Icons, Newsroom teaser) to the list of available Paragraphs in Campaign Overview pages.
- Provides a one column *Flexible* layout where the above Paragraphs can be added to eventually look like the current Brighton/Croydon homepage.

This pull request should be **reviewed only after** the [pull request for Homepage related Paragraphs](https://github.com/localgovdrupal/localgov_paragraphs/pull/6) has been accepted.