### PR TITLE
Added Box links listing paragraph

### DIFF
--- a/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
+++ b/config/install/field.field.node.localgov_campaigns_overview.localgov_campaigns_content.yml
@@ -6,6 +6,7 @@ dependencies:
     - node.type.localgov_campaigns_overview
     - paragraphs.paragraphs_type.localgov_accordion
     - paragraphs.paragraphs_type.localgov_box_link
+    - paragraphs.paragraphs_type.localgov_box_links_listing
     - paragraphs.paragraphs_type.localgov_call_out_box
     - paragraphs.paragraphs_type.localgov_documents
     - paragraphs.paragraphs_type.localgov_fact_box
@@ -49,6 +50,7 @@ settings:
       localgov_table: localgov_table
       localgov_text: localgov_text
       localgov_video: localgov_video
+      localgov_box_links_listing: localgov_box_links_listing
       localgov_ia_block: localgov_ia_block
       localgov_labelled_icon: localgov_labelled_icon
       localgov_featured_campaign: localgov_featured_campaign
@@ -68,6 +70,9 @@ settings:
       localgov_box_link:
         enabled: true
         weight: -29
+      localgov_box_links_listing:
+        enabled: true
+        weight: 25
       localgov_call_out_box:
         enabled: true
         weight: -28

--- a/config/install/field.field.node.localgov_campaigns_page.localgov_campaigns_content.yml
+++ b/config/install/field.field.node.localgov_campaigns_page.localgov_campaigns_content.yml
@@ -6,6 +6,7 @@ dependencies:
     - node.type.localgov_campaigns_page
     - paragraphs.paragraphs_type.localgov_accordion
     - paragraphs.paragraphs_type.localgov_box_link
+    - paragraphs.paragraphs_type.localgov_box_links_listing
     - paragraphs.paragraphs_type.localgov_call_out_box
     - paragraphs.paragraphs_type.localgov_documents
     - paragraphs.paragraphs_type.localgov_fact_box
@@ -45,6 +46,7 @@ settings:
       localgov_text: localgov_text
       localgov_video: localgov_video
       page_section: page_section
+      localgov_box_links_listing: localgov_box_links_listing
     target_bundles_drag_drop:
       from_library:
         weight: -21
@@ -58,6 +60,9 @@ settings:
       localgov_box_link:
         enabled: true
         weight: -31
+      localgov_box_links_listing:
+        enabled: true
+        weight: 25
       localgov_call_out_box:
         enabled: true
         weight: -30

--- a/modules/localgov_campaigns_paragraphs/config/install/core.entity_form_display.paragraph.localgov_box_link.default.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/core.entity_form_display.paragraph.localgov_box_link.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.localgov_box_link.localgov_image
     - field.field.paragraph.localgov_box_link.localgov_link
+    - field.field.paragraph.localgov_box_link.localgov_opens_in_a_new_window
     - paragraphs.paragraphs_type.localgov_box_link
   module:
     - link
@@ -27,6 +28,13 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  localgov_opens_in_a_new_window:
+    weight: 2
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
 hidden:
   created: true

--- a/modules/localgov_campaigns_paragraphs/config/install/core.entity_form_display.paragraph.localgov_box_links_listing.default.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/core.entity_form_display.paragraph.localgov_box_links_listing.default.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.localgov_box_links_listing.localgov_box_listing_theme
+    - field.field.paragraph.localgov_box_links_listing.localgov_heading_level
+    - field.field.paragraph.localgov_box_links_listing.localgov_paragraphs
+    - field.field.paragraph.localgov_box_links_listing.localgov_title
+    - paragraphs.paragraphs_type.localgov_box_links_listing
+  module:
+    - paragraphs
+id: paragraph.localgov_box_links_listing.default
+targetEntityType: paragraph
+bundle: localgov_box_links_listing
+mode: default
+content:
+  localgov_box_listing_theme:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  localgov_heading_level:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  localgov_paragraphs:
+    weight: 3
+    settings:
+      title: 'Box link'
+      title_plural: 'Box links'
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 1
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: localgov_box_link
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+    type: paragraphs
+    region: content
+  localgov_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/modules/localgov_campaigns_paragraphs/config/install/core.entity_view_display.paragraph.localgov_box_link.default.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/core.entity_view_display.paragraph.localgov_box_link.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.localgov_box_link.localgov_image
     - field.field.paragraph.localgov_box_link.localgov_link
+    - field.field.paragraph.localgov_box_link.localgov_opens_in_a_new_window
     - paragraphs.paragraphs_type.localgov_box_link
 id: paragraph.localgov_box_link.default
 targetEntityType: paragraph
@@ -21,3 +22,4 @@ content:
     region: content
 hidden:
   localgov_link: true
+  localgov_opens_in_a_new_window: true

--- a/modules/localgov_campaigns_paragraphs/config/install/core.entity_view_display.paragraph.localgov_box_links_listing.default.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/core.entity_view_display.paragraph.localgov_box_links_listing.default.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.localgov_box_links_listing.localgov_box_listing_theme
+    - field.field.paragraph.localgov_box_links_listing.localgov_heading_level
+    - field.field.paragraph.localgov_box_links_listing.localgov_paragraphs
+    - field.field.paragraph.localgov_box_links_listing.localgov_title
+    - paragraphs.paragraphs_type.localgov_box_links_listing
+  module:
+    - entity_reference_revisions
+id: paragraph.localgov_box_links_listing.default
+targetEntityType: paragraph
+bundle: localgov_box_links_listing
+mode: default
+content:
+  localgov_paragraphs:
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  localgov_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  localgov_box_listing_theme: true
+  localgov_heading_level: true

--- a/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_link.localgov_image.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_link.localgov_image.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: localgov_box_link
 label: Image
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_link.localgov_opens_in_a_new_window.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_link.localgov_opens_in_a_new_window.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_opens_in_a_new_window
+    - paragraphs.paragraphs_type.localgov_box_link
+id: paragraph.localgov_box_link.localgov_opens_in_a_new_window
+field_name: localgov_opens_in_a_new_window
+entity_type: paragraph
+bundle: localgov_box_link
+label: 'Opens in a new window'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_box_listing_theme.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_box_listing_theme.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_box_listing_theme
+    - paragraphs.paragraphs_type.localgov_box_links_listing
+  module:
+    - options
+id: paragraph.localgov_box_links_listing.localgov_box_listing_theme
+field_name: localgov_box_listing_theme
+entity_type: paragraph
+bundle: localgov_box_links_listing
+label: 'Box listing theme'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: grid
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_heading_level.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_heading_level.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_heading_level
+    - paragraphs.paragraphs_type.localgov_box_links_listing
+  module:
+    - options
+id: paragraph.localgov_box_links_listing.localgov_heading_level
+field_name: localgov_heading_level
+entity_type: paragraph
+bundle: localgov_box_links_listing
+label: 'Heading level'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: h2
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_paragraphs.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_paragraphs.yml
@@ -1,0 +1,87 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_paragraphs
+    - paragraphs.paragraphs_type.localgov_box_link
+    - paragraphs.paragraphs_type.localgov_box_links_listing
+  module:
+    - entity_reference_revisions
+id: paragraph.localgov_box_links_listing.localgov_paragraphs
+field_name: localgov_paragraphs
+entity_type: paragraph
+bundle: localgov_box_links_listing
+label: Paragraphs
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      localgov_box_link: localgov_box_link
+    target_bundles_drag_drop:
+      from_library:
+        weight: 21
+        enabled: false
+      localgov_accordion:
+        weight: 22
+        enabled: false
+      localgov_accordion_pane:
+        weight: 23
+        enabled: false
+      localgov_box_link:
+        enabled: true
+        weight: 24
+      localgov_box_links_listing:
+        weight: 25
+        enabled: false
+      localgov_call_out_box:
+        weight: 26
+        enabled: false
+      localgov_contact:
+        weight: 27
+        enabled: false
+      localgov_documents:
+        weight: 28
+        enabled: false
+      localgov_fact_box:
+        weight: 29
+        enabled: false
+      localgov_image:
+        weight: 30
+        enabled: false
+      localgov_link:
+        weight: 31
+        enabled: false
+      localgov_link_and_summary:
+        weight: 32
+        enabled: false
+      localgov_quote:
+        weight: 33
+        enabled: false
+      localgov_tab_panel:
+        weight: 36
+        enabled: false
+      localgov_table:
+        weight: 34
+        enabled: false
+      localgov_tabs:
+        weight: 35
+        enabled: false
+      localgov_text:
+        weight: 37
+        enabled: false
+      localgov_video:
+        weight: 38
+        enabled: false
+      page_section:
+        weight: 39
+        enabled: false
+      topic_list_builder:
+        weight: 40
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_title.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.field.paragraph.localgov_box_links_listing.localgov_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_title
+    - paragraphs.paragraphs_type.localgov_box_links_listing
+id: paragraph.localgov_box_links_listing.localgov_title
+field_name: localgov_title
+entity_type: paragraph
+bundle: localgov_box_links_listing
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/localgov_campaigns_paragraphs/config/install/field.storage.paragraph.localgov_box_listing_theme.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.storage.paragraph.localgov_box_listing_theme.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.localgov_box_listing_theme
+field_name: localgov_box_listing_theme
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: grid
+      label: Grid
+    -
+      value: boxes
+      label: Boxes
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_campaigns_paragraphs/config/install/field.storage.paragraph.localgov_opens_in_a_new_window.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/field.storage.paragraph.localgov_opens_in_a_new_window.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.localgov_opens_in_a_new_window
+field_name: localgov_opens_in_a_new_window
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_campaigns_paragraphs/config/install/paragraphs.paragraphs_type.localgov_box_links_listing.yml
+++ b/modules/localgov_campaigns_paragraphs/config/install/paragraphs.paragraphs_type.localgov_box_links_listing.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: localgov_box_links_listing
+label: 'Box links listing'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/modules/localgov_campaigns_paragraphs/css/localgov-box-links-listing.css
+++ b/modules/localgov_campaigns_paragraphs/css/localgov-box-links-listing.css
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Basic styling for Box links listing paragraph.
+ */
+
+.box-links-listing__list {
+  display: flex;
+  list-style-type: none;
+}
+
+/* 'Grid' theme. */
+.box-links-listing--grid .box-links-listing__list-item {
+  border: 1px solid #f2f2f2;
+  margin: 0 -1px -1px 0;
+  padding: 20px;
+}
+
+/* 'Boxes' theme. */
+.box-links-listing--boxes {
+  margin: 0 -15px;
+}
+
+.box-links-listing--boxes .box-links-listing__list-item {
+  padding: 0 15px;
+}

--- a/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.libraries.yml
+++ b/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.libraries.yml
@@ -10,6 +10,11 @@ localgov_accordion:
   js:
     js/localgov-accordion.js: {}
 
+localgov_box_links_listing:
+  css:
+    base:
+      css/localgov-box-links-listing.css: {}
+
 localgov_table_paragraph:
   css:
     base:

--- a/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.module
+++ b/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.module
@@ -14,6 +14,10 @@ use Drupal\image\Entity\ImageStyle;
  */
 function localgov_campaigns_paragraphs_theme($existing, $type, $theme, $path) {
   return [
+    'field__paragraph__localgov_paragraphs__localgov_box_links_listing' => [
+      'template' => 'field--paragraph--localgov-paragraphs--localgov-box-links-listing',
+      'base hook' => 'field',
+    ],
     'paragraph__localgov_accordion' => [
       'template' => 'paragraph--localgov-accordion',
       'base hook' => 'paragraph',
@@ -24,6 +28,10 @@ function localgov_campaigns_paragraphs_theme($existing, $type, $theme, $path) {
     ],
     'paragraph__localgov_box_link' => [
       'template' => 'paragraph--localgov-box-link',
+      'base hook' => 'paragraph',
+    ],
+    'paragraph__localgov_box_links_listing' => [
+      'template' => 'paragraph--localgov-box-links-listing',
       'base hook' => 'paragraph',
     ],
     'paragraph__localgov_call_out_box' => [
@@ -66,11 +74,22 @@ function localgov_campaigns_paragraphs_preprocess_paragraph(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
 
+  // Create heading element for paragraphs with a heading level field and
+  // non-empty title field.
+  if ($paragraph->hasField('localgov_heading_level') && $paragraph->hasField('localgov_title') && !$paragraph->get('localgov_title')->isEmpty()) {
+    $heading_text = $paragraph->get('localgov_title')->value;
+    $heading_level = $paragraph->get('localgov_heading_level')->value;
+    $variables['heading'] = _localgov_campaigns_paragraphs_create_heading($heading_text, $heading_level);
+  }
+
   if ($paragraph->bundle() === 'localgov_box_link') {
     if (!$paragraph->get('localgov_link')->isEmpty()) {
       $link = $paragraph->get('localgov_link')->first()->getValue();
-      $variables['localgov_link']['title'] = $link['title'];
-      $variables['localgov_link']['url'] = Url::fromUri($link['uri']);
+      $variables['localgov_link'] = [
+        'title' => $link['title'],
+        'url' => Url::fromUri($link['uri']),
+        'open_in_new_window' => $paragraph->get('localgov_opens_in_a_new_window')->value
+      ];
     }
   }
 
@@ -109,14 +128,6 @@ function localgov_campaigns_paragraphs_preprocess_paragraph(&$variables) {
     if (!$paragraph->get('field_video_url')->isEmpty()) {
       $video = $paragraph->get('field_video_url')->first()->getValue();
       $variables['field_video_url'] = $video['uri'];
-    }
-  }
-
-  if ($paragraph->bundle() === 'localgov_accordion' || $paragraph->bundle() === 'localgov_accordion_pane') {
-    if (!$paragraph->get('localgov_title')->isEmpty()) {
-      $heading_text = $paragraph->get('localgov_title')->value;
-      $heading_level = $paragraph->get('localgov_heading_level')->value;
-      $variables['heading'] = _localgov_campaigns_paragraphs_create_heading($heading_text, $heading_level);
     }
   }
 }

--- a/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.module
+++ b/modules/localgov_campaigns_paragraphs/localgov_campaigns_paragraphs.module
@@ -88,7 +88,7 @@ function localgov_campaigns_paragraphs_preprocess_paragraph(&$variables) {
       $variables['localgov_link'] = [
         'title' => $link['title'],
         'url' => Url::fromUri($link['uri']),
-        'open_in_new_window' => $paragraph->get('localgov_opens_in_a_new_window')->value
+        'open_in_new_window' => $paragraph->get('localgov_opens_in_a_new_window')->value,
       ];
     }
   }

--- a/modules/localgov_campaigns_paragraphs/templates/field--paragraph--localgov-paragraphs--localgov-box-links-listing.html.twig
+++ b/modules/localgov_campaigns_paragraphs/templates/field--paragraph--localgov-paragraphs--localgov-box-links-listing.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a Paragrahs field in Box links listing
+ * paragraphs.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if multiple %}
+  <ul{{ attributes.addClass('box-links-listing__list') }}>
+    {% for item in items %}
+      <li{{ item.attributes.addClass('box-links-listing__list-item') }}>{{ item.content }}</li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <div{{ attributes.addClass('box-links-listing__list') }}>
+    {% for item in items %}
+      <div{{ item.attributes.addClass('box-links-listing__list-item') }}>{{ item.content }}</div>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/modules/localgov_campaigns_paragraphs/templates/field--paragraph--localgov-paragraphs--localgov-box-links-listing.html.twig
+++ b/modules/localgov_campaigns_paragraphs/templates/field--paragraph--localgov-paragraphs--localgov-box-links-listing.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for a Paragrahs field in Box links listing
+ * Default theme implementation for a Paragraphs field in Box links listing
  * paragraphs.
  *
  * To override output, copy the "field.html.twig" from the templates directory

--- a/modules/localgov_campaigns_paragraphs/templates/paragraph--localgov-box-links-listing.html.twig
+++ b/modules/localgov_campaigns_paragraphs/templates/paragraph--localgov-box-links-listing.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a Box links listing paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.
@@ -38,13 +38,26 @@
  * @ingroup themeable
  */
 #}
-<div class="box-link">
-  <a href="{{ localgov_link.url }}"
-    {% if localgov_link.open_in_new_window %} target="_blank" {% endif %}>
-    {{ content.localgov_image }}
-  	<span>{{ localgov_link.title }}</span>
-    {% if localgov_link.open_in_new_window %}
-      <span class="visually-hidden">{{ '(opens in a new window)'|t }}</span>
-    {% endif %}
-  </a>
-</div>
+
+{% set theme = paragraph.get('localgov_box_listing_theme').value %}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'box-links-listing',
+    'box-links-listing--' ~ theme|clean_class
+  ]
+%}
+
+{{ attach_library('localgov_campaigns_paragraphs/localgov_box_links_listing') }}
+
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ heading }}
+      {{ content.localgov_paragraphs }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}

--- a/modules/localgov_campaigns_paragraphs/tests/src/Functional/CampaignsParagraphsAdministrationTest.php
+++ b/modules/localgov_campaigns_paragraphs/tests/src/Functional/CampaignsParagraphsAdministrationTest.php
@@ -55,6 +55,14 @@ class CampaignsParagraphsAdministrationTest extends ParagraphsTestBase {
     $this->drupalGet('/admin/structure/paragraphs_type/localgov_box_link/fields');
     $this->assertSession()->pageTextContains('localgov_image');
     $this->assertSession()->pageTextContains('localgov_link');
+    $this->assertSession()->pageTextContains('localgov_opens_in_a_new_window');
+
+    // Check 'Box links listing' fields.
+    $this->drupalGet('/admin/structure/paragraphs_type/localgov_box_links_listing/fields');
+    $this->assertSession()->pageTextContains('localgov_title');
+    $this->assertSession()->pageTextContains('localgov_heading_level');
+    $this->assertSession()->pageTextContains('localgov_paragraphs');
+    $this->assertSession()->pageTextContains('localgov_box_listing_theme');
 
     // Check 'Call out box' fields.
     $this->drupalGet('/admin/structure/paragraphs_type/localgov_call_out_box/fields');


### PR DESCRIPTION
Also made some changes to 'Box link' paragraph (made image field optional, and added 'Opens in a new window' checkbox), which is a sub-component of the 'Box links listing' paragraph.

Relates to [Add 'Grid display' paragraph type](https://github.com/localgovdrupal/localgov_campaigns/issues/43) - I've changed the name of that paragraph, as I think 'Grid display' doesn't describe the purpose of that paragraph very well.
