### PR TITLE
Update inline alias for test branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: echo "::set-env name=GIT_BRANCH::${GITHUB_HEAD_REF}"
 
       - name: Grab test target
-        run: composer --working-dir=html require ${{ github.repository }}:"dev-${GIT_BRANCH} as dev-master"
+        run: composer --working-dir=html require ${{ github.repository }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
 
       - name: Start Docker environment
         run: docker-compose up -d


### PR DESCRIPTION
localgovdrupal/localgov's minimum version requirement for localgovdrupal/localgov_campaigns is now ^1.0@alpha.  The inline alias used in the test workflow needs to match that.